### PR TITLE
Fix for UnboundLocalError: local variable 'io_ms2' referenced before assignment

### DIFF
--- a/stats2rrd.py
+++ b/stats2rrd.py
@@ -106,6 +106,8 @@ def disk_busy(device, sample_duration=1):
             time.sleep(sample_duration)
             content2 = f2.read()
     sep = '%s ' % device
+    io_ms1 = '0'
+    io_ms2 = '0'
     for line in content1.splitlines():
         if sep in line:
             io_ms1 = line.strip().split(sep)[1].split()[9]


### PR DESCRIPTION
Hi,
I tried to install your linux dashboard on my Raspberry Pi and ran into a minor issue (see below). Fixed it this morning and thought you might be interested in merging it back to your master.

Kind regards

Anders
## HOW TO TRIGGER

Execute the script (following configuration according to the setup instructions)

```
$ ./stats2rrd.py
Traceback (most recent call last):
  File "./stats2rrd.py", line 218, in <module>
    main()
  File "./stats2rrd.py", line 41, in main
    disk_pct = disk_busy(DISK, 5)
  File "./stats2rrd.py", line 117, in disk_busy
    delta = int(io_ms2) - int(io_ms1)
UnboundLocalError: local variable 'io_ms2' referenced before assignment
```
## ENVIRONMENT

```
Device: Raspberry Pi model B, 512MB RAM
OS: Linux raspberrypi 3.6.11+ #371 PREEMPT Thu Feb 7 16:31:35 GMT 2013 armv6l
Python: v2.7.3
```
